### PR TITLE
fix(gmerge): Fix KeyError handling when update.conf invalid

### DIFF
--- a/gmerge
+++ b/gmerge
@@ -28,7 +28,7 @@ class GMerger(object):
       self.devkit_url = self.update_conf['DEVSERVER']
       self.board_name = self.update_conf['COREOS_RELEASE_BOARD']
     except KeyError, e:
-      sys.exit('Could not find /etc/coreos/update.conf value: ' + e)
+      sys.exit('Could not find /etc/coreos/update.conf value: ' + e.message)
 
   def ParseUpdateConf(self, conf_lines):
     """Convert a list of KEY=VALUE lines to a dictionary."""


### PR DESCRIPTION
### Before:

```
core@localhost ~ $ /usr/bin/gmerge coreos-base/update_engine
Traceback (most recent call last):
  File "/usr/bin/gmerge", line 136, in <module>
    main()
  File "/usr/bin/gmerge", line 121, in main
    merger = GMerger(conf_data)
  File "/usr/bin/gmerge", line 31, in __init__
    sys.exit('Could not find /etc/coreos/update.conf value: ' + e)
TypeError: cannot concatenate 'str' and 'exceptions.KeyError' objects
```
### After:

```
core@localhost ~ $ ./gmerge coreos-base/update_engine
Could not find /etc/coreos/update.conf value: DEVSERVER
```

Related: https://github.com/coreos/docs/pull/212
