### PR TITLE
bash_completion: do not modify git $PS1 prompt behavior

### DIFF
--- a/host/repo_bash_completion
+++ b/host/repo_bash_completion
@@ -64,36 +64,3 @@ _complete_repo() {
 }
 
 complete -F _complete_repo repo
-
-# Add a way to get the "m" branch from repo easily; used by __git_branch_ps1()
-#
-# Repo seems to maintain a phony 'm/' remote and it always seems to be the name
-# of the manifest branch.  This will retrieve it.
-__git_m_branch() {
-  local git_dir=$(git rev-parse --git-dir 2> /dev/null)
-  if [ -n "${git_dir}" ]; then
-    echo $(cd ${git_dir}/refs/remotes/m 2> /dev/null && ls)
-  fi
-}
-
-# A "subclass" of __git_ps1 that adds the manifest branch name into the prompt.
-# ...if you're on manifest branch "0.11.257.B" and local branch "lo" and
-# pass " (%s)", we'll output " (0.11.257.B/lo)".  Note that we'll never show
-# the manifest branch 'master', since it's so common.
-__git_branch_ps1() {
-  local format_str="${1:- (%s)}"
-  local m_branch=$(__git_m_branch)
-  if [ "${m_branch}" != "master" -a -n "${m_branch}" ]; then
-    format_str=$(printf "${format_str}" "${m_branch}/%s")
-  fi
-  # for subshells, prefix the prompt with the shell nesting level
-  local lshlvl=""
-  [ ! -z "${SHLVL##*[!0-9]*}" ] && [ ${SHLVL} -gt 1 ] && lshlvl="${SHLVL} "
-  __git_ps1 "${lshlvl}${format_str}"
-}
-
-# Prompt functions should not error when in subshells
-export -f __gitdir
-export -f __git_ps1
-export -f __git_m_branch
-export -f __git_branch_ps1


### PR DESCRIPTION
Referring to functions defined elsewhere causes annoying noise when
said-elsewhere is not actually available. Also this code for detecting
the repo manifest branch never worked correctly. It simply lists all
branches with the m/ remote prefix, not the current one being used.
This has always annoyed me but I didn't know what was doing it till now.
