### PR TITLE
devserver: use the CoreOS app id

### DIFF
--- a/autoupdate_lib.py
+++ b/autoupdate_lib.py
@@ -10,7 +10,7 @@ import time
 from xml.dom import minidom
 
 
-APP_ID = '87efface-864d-49a5-9bb3-4b050a7c227a'
+APP_ID = 'e96281a6-d1af-4bde-9a0a-97b76e56dc57'
 
 # Responses for the various Omaha protocols indexed by the protocol version.
 UPDATE_RESPONSE = {}


### PR DESCRIPTION
currently update_engine doesn't check that the appid it gets back is the appid it actually requested, similarly devserver doesn't check the appid requested and returns this hard-coded one.

Both issues need fixing but for now make things not explode.