### PR TITLE
Making legacy_image optional as it broke the pregenerate option

### DIFF
--- a/autoupdate.py
+++ b/autoupdate.py
@@ -451,7 +451,7 @@ class Autoupdate(object):
                                              legacy_image=legacy_image)
 
   def GenerateUpdatePayload(self, board, client_version, static_image_dir,
-                            legacy_image):
+                            legacy_image=True):
     """Generates an update for an image and returns the relative payload dir.
 
     Returns:


### PR DESCRIPTION
Since we're pre-generating the image, this flag cannot be derived dynamically. One option is to make it optional. Another option is to pass this flag from the command line. Kindly review and let me know what you think. 